### PR TITLE
feat(overridesToOverride): backward compatibility for overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,8 +559,6 @@ Because ES classes are not plain objects, you can't have an object property like
 
 This plugin allows you to configure `metadata` and `renderer` as class properties (static or not) and the plugin will convert it to object properties for the extend call.
 
-This:
-
 ```js
 class MyControl extends SAPClass {
     static renderer = MyControlRenderer;
@@ -570,7 +568,7 @@ class MyControl extends SAPClass {
 }
 ```
 
-Becomes:
+is converted to
 
 ```js
 const MyControl = SAPClass.extend('MyControl', {
@@ -579,6 +577,27 @@ const MyControl = SAPClass.extend('MyControl', {
         ...
     }
 });
+```
+It additionally supports the usage of the new `overrides` class property required for a `ControllerExtension`.
+(For backward compatibility, you can use `overridesToOverride: true`)
+```js
+class MyExtension extends ControllerExtension {
+
+  static overrides = {
+    onPageReady: function () { }
+  }
+}
+```
+is converted to
+
+```js
+const MyExtension = ControllerExtension.extend("MyExtension", {
+    overrides: {
+      onPageReady: function () {}
+    }
+  });
+  return MyExtension;
+});"
 ```
 
 Since class properties are an early ES proposal, TypeScript's compiler (like babel's class properties transform) moves static properties outside the class definition, and moves instance properties inside the constructor (even if TypeScript is configured to output ESNext).
@@ -639,7 +658,8 @@ const MyControl = SAPClass.extend('MyControl', {
 - `moveControllerPropsToOnInit` (Default: false) Moves class props in a controller to the onInit method instead of constructor.
 - `moveControllerConstructorToOnInit` (Default: false) Moves existing constructor code in a controller to the onInit method. Enabling will auto-enable `moveControllerPropsToOnInit`.
 - `addControllerStaticPropsToExtend` (Default: false) Moves static props of a controller to the extends call. Useful for formatters.
-- `onlyMoveClassPropsUsingThis` (Default: false) Set to use old behaviour where only instance class props referencing `this` would be moved to the constructor or onInit. New default is to always move instance props.
+- `onlyMoveClassPropsUsingThis` (Default: false) Set to use old behavior where only instance class props referencing `this` would be moved to the constructor or onInit. New default is to always move instance props.
+- `overridesToOverride` (Default: false) Changes the name of the static overrides to override when being added to ControllerExtension.extend() allowing to use the new overrides keyword with older UI5 versions
 
 \* 'collapsing' named exports is a combination of simply ignoring them if their definition is the same as a property on the default export, and also assigning them to the default export.
 

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -179,6 +179,17 @@ exports[`classes class-convert-controller-extension-static-prop.controller.js 1`
 });"
 `;
 
+exports[`classes class-convert-controller-extension-static-prop-compatibility.controller.js 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/ControllerExtension"], function (ControllerExtension) {
+  const MyExtension = ControllerExtension.extend("fixtures.classes.MyExtension", {
+    override: {
+      onPageReady: function () {}
+    }
+  });
+  return MyExtension;
+});"
+`;
+
 exports[`classes class-convert-controller-multi.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller", "other"], function (SAPController, __Other) {
   function _interopRequireDefault(obj) {

--- a/packages/plugin/__test__/fixtures/classes/class-convert-controller-extension-static-prop-compatibility.controller.js
+++ b/packages/plugin/__test__/fixtures/classes/class-convert-controller-extension-static-prop-compatibility.controller.js
@@ -1,0 +1,8 @@
+import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
+
+export default class MyExtension extends ControllerExtension {
+
+  static overrides = {
+    onPageReady: function () { }
+  }
+}

--- a/packages/plugin/__test__/options.js
+++ b/packages/plugin/__test__/options.js
@@ -30,6 +30,9 @@ const Options = {
     "class-convert-controller-extend-static-prop": {
       addControllerStaticPropsToExtend: true,
     },
+    "class-convert-controller-extension-static-prop-compatibility.controller": {
+      overridesToOverride: true
+    },
     "class-convert-all": {
       autoConvertAllExtendClasses: true,
     },

--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -57,13 +57,10 @@ export function convertClassToUI5Extend(
     ? Object.keys(extraStaticProps)
     : ["metadata", "renderer", "overrides"];
 
-  for (const propName of staticPropsToAdd) {
+  for (let propName of staticPropsToAdd) {
     if (extraStaticProps[propName]) {
       extendProps.push(
-        t.objectProperty(
-          t.identifier(propName === "overrides" ? "override" : propName),
-          extraStaticProps[propName]
-        )
+        t.objectProperty(t.identifier(propName), extraStaticProps[propName])
       );
     }
   }
@@ -118,15 +115,12 @@ export function convertClassToUI5Extend(
       }
     } else if (t.isClassProperty(member)) {
       if (!member.value) continue; // un-initialized static class prop (typescript)
-      if (
-        memberName === "metadata" ||
-        memberName === "renderer" ||
-        memberName === "overrides"
-      ) {
-        // Special handling for TypeScript limitation where metadata, renderer and overrides must be properties.
-        /*if (member.key.name === "overrides") {
+
+      // Special handling for TypeScript limitation where metadata, renderer and overrides must be properties.
+      if (["metadata", "renderer", "overrides"].includes(memberName)) {
+        if (opts.overridesToOverride && member.key.name === "overrides") {
           member.key.name = "override";
-        }*/
+        }
         extendProps.unshift(buildObjectProperty(member));
       } else if (member.static) {
         if (moveStaticStaticPropsToExtend) {

--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -57,7 +57,7 @@ export function convertClassToUI5Extend(
     ? Object.keys(extraStaticProps)
     : ["metadata", "renderer", "overrides"];
 
-  for (let propName of staticPropsToAdd) {
+  for (const propName of staticPropsToAdd) {
     if (extraStaticProps[propName]) {
       extendProps.push(
         t.objectProperty(t.identifier(propName), extraStaticProps[propName])
@@ -66,7 +66,7 @@ export function convertClassToUI5Extend(
   }
 
   for (const member of node.body.body) {
-    let memberName = member.key.name;
+    const memberName = member.key.name;
 
     if (t.isClassMethod(member)) {
       const func = t.functionExpression(


### PR DESCRIPTION
## Description
Thanks to #82 done by @akudev, it is possible to define controller extensions overrides nicely in with class syntax, however, it only works with very recent UI5 versions. To be backward compatible, I would like to add a configuration option allowing to convert `overrides` to `override`.

Contributes to fixing https://github.com/SAP/ui5-typescript/issues/332

## Tasks
- [x] add required logic to convert `overrides` to `override` if the option is true
- [x] add test case
- [x] updated documentation