### PR TITLE
fix: catch err for dynamic import to sap.ui.require

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1023,6 +1023,8 @@ exports[`imports import-dynamic.js 1`] = `
           module.__esModule = true;
           resolve(module);
         }
+      }, err => {
+        reject(err);
       });
     });
   }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -20,6 +20,7 @@
     "lint:staged": "lint-staged",
     "test": "jest __test__ --coverage=no",
     "test:watch": "npm test -- --watch",
+    "test:update-snapshot": "jest --updateSnapshot",
     "prepare": "npm test && npm run build",
     "format": "prettier --write 'src/**/*.js'"
   },

--- a/packages/plugin/src/utils/templates.js
+++ b/packages/plugin/src/utils/templates.js
@@ -94,8 +94,10 @@ export const buildDynamicImportHelper = template(`
           module.__esModule = true;
           resolve(module);
         }
-      })
-    })
+      }, (err) => {
+        reject(err);
+      });
+    });
   }
 `);
 


### PR DESCRIPTION
To avoid an uncaught exception when rewriting dynamic imports and catching errors, the error handler for the sap.ui.require needs to be passed and finally reject the Promise. This will make the following code working:

```ts
import("luxon").then(({ Info }) => {
  console.log(`Luxon loaded: ${Info.toString()}`);
}).catch((ex) => {
  console.log("Failed to load luxon!");
});
```