### PR TITLE
fix: dynamic imports of empty modules must not fail

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1012,17 +1012,15 @@ exports[`imports import-dynamic.js 1`] = `
   function __ui5_require_async(path) {
     return new Promise((resolve, reject) => {
       sap.ui.require([path], module => {
-        if (!module) {
-          return reject("No module returned from " + path);
-        } else if (module.__esModule) {
-          return resolve(module);
-        } else if (module.default) {
-          return reject(new Error(path + " module includes a 'default' property but not __esModule. Cannot use as dynamic import"));
-        } else {
-          module.default = typeof module === "object" ? Object.assign({}, module) : module;
-          module.__esModule = true;
-          resolve(module);
+        module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
+          default: module
+        } : module;
+        if (!module.__esModule) {
+          Object.defineProperty(module, "__esModule", {
+            value: true
+          });
         }
+        resolve(module);
       }, err => {
         reject(err);
       });


### PR DESCRIPTION
Dynamic imports of modules exporting nothing must not fail. The native dynamic import doesn't fail either for that scenario. As the dynamic import is translated to `sap.ui.require`, I also checked how this behaves. This also doesn't fail and returns undefined for such modules. The same happens for requirejs. The following JSBin demonstrates this behavior: [https://jsbin.com/yevobusuyu/1/edit?html,output](https://jsbin.com/yevobusuyu/1/edit?html,output )

The dynamic import script template simulates the default export for non-ES modules so that the TypeScript code completion can be properly used, e.g.

```ts
(await import("sap/m/Button")).default => sap/m/Button module
```

as we typically use `export default` for the UI5 modules:

```ts
export default class Button
```

The dynamic import script template also ensures named imports, e.g.

```ts
(await import("sap/m/library")).ButtonType => sap/m/ButtonType 
```

Libraries don't have a `default` export as the TypeScript code completion doesn't suggest it. So the code completion and the dynamic import template are in sync.
