### PR TITLE
fix: dynamic import must not handle __esModule flagged modules

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1012,10 +1012,10 @@ exports[`imports import-dynamic.js 1`] = `
   function __ui5_require_async(path) {
     return new Promise((resolve, reject) => {
       sap.ui.require([path], module => {
-        module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
-          default: module
-        } : module;
         if (!module.__esModule) {
+          module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
+            default: module
+          } : module;
           Object.defineProperty(module, "__esModule", {
             value: true
           });

--- a/packages/plugin/src/utils/templates.js
+++ b/packages/plugin/src/utils/templates.js
@@ -135,14 +135,22 @@ export const buildDefaultImportDeconstructor = template(`
  *
  * (await import("./non/exporting/module")) => { __esModule: true, ... }
  * (await import("./non/exporting/module")) => undefined
+ *
+ * 5.) Other dependencies (jsPDF)
+ *
+ * (await import("jsPDF")) => { __esModule: true, jsPDF: ?, ... }
+ * (await import("sap/m/MessageBox")).jsPDF => jsPDF
+ *
+ * When requiring other dependencies they are already flagged as __esModule
+ * and must not be processed in our dynamic import to require handler.
  */
 // TODO: inject __extends instead of Object.assign unless useBuiltIns in set
 export const buildDynamicImportHelper = template(`
   function __ui5_require_async(path) {
     return new Promise((resolve, reject) => {
       sap.ui.require([path], (module) => {
-        module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? { default: module } : module;
         if (!module.__esModule) {
+          module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? { default: module } : module;
           Object.defineProperty(module, "__esModule", { value: true });
         }
         resolve(module);


### PR DESCRIPTION
Standard NPM packages like `jsPDF` are also detected as `static object`s but compared to UI5 `static object`s they must not be returned as `default`.

NPM `static object`s:

```js
(await import("jsPDF")); // { __esModule: true, jsPDF: /* jsPDF class */, ... }
(await import("sap/m/MessageBox")).jsPDF // jsPDF
```

UI5 `static object`: 

```js
(await import("sap/m/MessageBox")) // { __esModule: true, default: /* sap/m/MessageBox */... }
(await import("sap/m/MessageBox")).default // sap/m/MessageBox
(await import("sap/m/MessageBox")).default.alert // sap/m/MessageBox#alert
```
