### PR TITLE
fix: properly handle dynamic import of non-existing modules

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1012,7 +1012,7 @@ exports[`imports import-dynamic.js 1`] = `
   function __ui5_require_async(path) {
     return new Promise((resolve, reject) => {
       sap.ui.require([path], module => {
-        if (!module.__esModule) {
+        if (!(module && module.__esModule)) {
           module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
             default: module
           } : module;

--- a/packages/plugin/src/utils/templates.js
+++ b/packages/plugin/src/utils/templates.js
@@ -149,7 +149,7 @@ export const buildDynamicImportHelper = template(`
   function __ui5_require_async(path) {
     return new Promise((resolve, reject) => {
       sap.ui.require([path], (module) => {
-        if (!module.__esModule) {
+        if (!(module && module.__esModule)) {
           module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? { default: module } : module;
           Object.defineProperty(module, "__esModule", { value: true });
         }


### PR DESCRIPTION
This fix handles the last open scenario of non-existing modules:

```js
// dynamic import of a provided library
import("luxon").then(({ Info }) => {
	console.log(`Luxon loaded: ${Info.toString()}`);
}).catch((ex) => {
	console.log("Failed to load luxon from application runtime environment!", ex);
});
```

This must not fail in the dynamic import function because of the `module` being `undefined` and the `module.__esModule` runs into an undefined error.