### PR TITLE
fix: sap.ui.define without callback function

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -566,6 +566,8 @@ exports[`classes class-fix-with-existing-define.js 1`] = `
 });"
 `;
 
+exports[`classic sap-ui-define.ts 1`] = `"sap.ui.define("", ["foo/bar/MyResource"]);"`;
+
 exports[`examples Animal.js 1`] = `
 "sap.ui.define(["sap/ui/base/ManagedObject"], function (ManagedObject) {
   const Animal = ManagedObject.extend("examples.Animal", {

--- a/packages/plugin/__test__/fixtures/classic/sap-ui-define.ts
+++ b/packages/plugin/__test__/fixtures/classic/sap-ui-define.ts
@@ -1,0 +1,1 @@
+sap.ui.define("", ["foo/bar/MyResource"]);

--- a/packages/plugin/src/classes/visitor.js
+++ b/packages/plugin/src/classes/visitor.js
@@ -138,7 +138,7 @@ function isSuperApply(callee) {
 function getRequiredParamsOfSAPUIDefine(path, node) {
   const defineArgs = node.arguments;
   const callbackNode = defineArgs.find((argNode) => t.isFunction(argNode));
-  return callbackNode.params; // Identifier
+  return callbackNode?.params || []; // Identifier
 }
 
 /**


### PR DESCRIPTION
Allows using `sap.ui.define` in classic SAPUI5 runtime code without a callback function. In this case, the parameter names are not relevant and can be ignored. Therefore, the code now just returns an empty array when no callback function and params are found.

Fixes #50