### PR TITLE
fix: add support for import.meta.url|resolve

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -566,6 +566,20 @@ exports[`classes class-fix-with-existing-define.js 1`] = `
 });"
 `;
 
+exports[`classes class-import-meta.js 1`] = `
+"sap.ui.define(["require", "module", "sap/SAPClass"], function (require, module, SAPClass) {
+  const MyClass = SAPClass.extend("test.fixtures.classes.MyClass", {
+    myUrl: function _myUrl() {
+      return module.url;
+    },
+    resolveUrl: function _resolveUrl(url) {
+      return require.toUrl(url);
+    }
+  });
+  return MyClass;
+});"
+`;
+
 exports[`classic sap-ui-define.ts 1`] = `"sap.ui.define("", ["foo/bar/MyResource"]);"`;
 
 exports[`comments copyright.js 1`] = `

--- a/packages/plugin/__test__/fixtures/classes/class-import-meta.js
+++ b/packages/plugin/__test__/fixtures/classes/class-import-meta.js
@@ -1,0 +1,13 @@
+import SAPClass from "sap/SAPClass";
+
+/**
+ * @name test.fixtures.classes.MyClass
+ */
+export default class MyClass extends SAPClass {
+  myUrl() {
+    return import.meta.url;
+  }
+  resolveUrl(url) {
+    return import.meta.resolve(url);
+  }
+}


### PR DESCRIPTION
With this change we add support for `import.meta.url` and `import.meta.resolve()` for the transpilation step of the plugin. 

This is how `import.meta.url` is handled:

```js
// ES syntax:
import.meta.url;

// UI5 AMD-like syntax:
sap.ui.define(["module"], function(module) {

  module.url;

});
```

This is how `import.meta.resolve(...)` is handled:

```js
// ES syntax:
import.meta.resolve(...);

// UI5 AMD-like syntax:
sap.ui.define(["require"], function(require) {

  require.toUrl(...);

});
```

Fixes #103