### PR TITLE
fix: ensure template to be ES5 compliant

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1160,8 +1160,8 @@ exports[`imports import-duplicate-src-3.js 1`] = `
 exports[`imports import-dynamic.js 1`] = `
 "sap.ui.define([], function () {
   function __ui5_require_async(path) {
-    return new Promise((resolve, reject) => {
-      sap.ui.require([path], module => {
+    return new Promise(function (resolve, reject) {
+      sap.ui.require([path], function (module) {
         if (!(module && module.__esModule)) {
           module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
             default: module
@@ -1171,7 +1171,7 @@ exports[`imports import-dynamic.js 1`] = `
           });
         }
         resolve(module);
-      }, err => {
+      }, function (err) {
         reject(err);
       });
     });

--- a/packages/plugin/src/utils/templates.js
+++ b/packages/plugin/src/utils/templates.js
@@ -147,14 +147,14 @@ export const buildDefaultImportDeconstructor = template(`
 // TODO: inject __extends instead of Object.assign unless useBuiltIns in set
 export const buildDynamicImportHelper = template(`
   function __ui5_require_async(path) {
-    return new Promise((resolve, reject) => {
-      sap.ui.require([path], (module) => {
+    return new Promise(function(resolve, reject) {
+      sap.ui.require([path], function(module) {
         if (!(module && module.__esModule)) {
           module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? { default: module } : module;
           Object.defineProperty(module, "__esModule", { value: true });
         }
         resolve(module);
-      }, (err) => {
+      }, function(err) {
         reject(err);
       });
     });


### PR DESCRIPTION
Although Promise is no ES5 functionality, it is more about the JavaScript syntax. Promise could be polyfilled but Arrow functions can't be used in ES5 code. Therefore, the plugin generates syntactical ES5 code via its templates.