### PR TITLE
fix: by default add "use strict" directive to sap.ui.define

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,19 @@ Becomes:
 
 ```js
 sap.ui.define(['app/File'], function(__File) {
-    function _interopRequireDefault(obj) {
-        return (obj && obj.__esModule && (typeof obj.default !== "undefined")) ? obj.default : obj;
-    }
-    const Default = _interopRequireDefault(__File);
-    const Name1 = __File["Name1"];
-    const Name2 = __File["Name2"];
-    const File = __File;
+  "use strict";
+
+  function _interopRequireDefault(obj) {
+      return (obj && obj.__esModule && (typeof obj.default !== "undefined")) ? obj.default : obj;
+  }
+  const Default = _interopRequireDefault(__File);
+  const Name1 = __File["Name1"];
+  const Name2 = __File["Name2"];
+  const File = __File;
 }
 ```
 
-Also refer to the `noImportInteropPrefixes` option below.
+Also refer to the `noImportInteropPrefixes` and `neverUseStrict` option below.
 
 #### Dynamic Import
 
@@ -327,6 +329,7 @@ Outputs:
 
 ```js
 "use strict";
+
 const X = 1;
 sap.ui.define(["./a"], A => {
   return {
@@ -335,6 +338,8 @@ sap.ui.define(["./a"], A => {
   };
 });
 ```
+
+Also refer to the `neverUseStrict` option below.
 
 ### Converting ES classes into Control.extend(..) syntax
 
@@ -581,8 +586,10 @@ const MyControl = SAPClass.extend('MyControl', {
     }
 });
 ```
+
 It additionally supports the usage of the new `overrides` class property required for a `ControllerExtension`.
 (For backward compatibility, you can use `overridesToOverride: true`)
+
 ```js
 class MyExtension extends ControllerExtension {
 
@@ -591,6 +598,7 @@ class MyExtension extends ControllerExtension {
   }
 }
 ```
+
 is converted to
 
 ```js
@@ -683,6 +691,7 @@ sap.ui.define(["sap/ui/core/Control"], function(Control) { /* ... */ });
 - `addControllerStaticPropsToExtend` (Default: false) Moves static props of a controller to the extends call. Useful for formatters.
 - `onlyMoveClassPropsUsingThis` (Default: false) Set to use old behavior where only instance class props referencing `this` would be moved to the constructor or onInit. New default is to always move instance props.
 - `overridesToOverride` (Default: false) Changes the name of the static overrides to override when being added to ControllerExtension.extend() allowing to use the new overrides keyword with older UI5 versions
+- `neverUseStrict` (Default: false) Disables the addition of the `"use strict";` directive to the program or `sap.ui.define` callback function.
 
 \* 'collapsing' named exports is a combination of simply ignoring them if their definition is the same as a property on the default export, and also assigning them to the default export.
 

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`classes class-computed-prop.js 1`] = `
 "sap.ui.define(["sap/class"], function (Controller) {
+  "use strict";
+
   const name = Symbol("_name");
   const Test = Controller.extend("my.TestController", {
     constructor: function constructor() {
@@ -26,6 +28,8 @@ exports[`classes class-computed-prop.js 1`] = `
 
 exports[`classes class-convert-all.js 1`] = `
 "sap.ui.define(["sap/class"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("fixtures.classes.MyClass", {});
   class BaseClass {}
   class MyError extends Error {}
@@ -34,6 +38,8 @@ exports[`classes class-convert-all.js 1`] = `
 
 exports[`classes class-convert-calling-super-apply.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("fixtures.classes.MyController", {
     constructor: function _constructor(arg) {
       console.log("before super");
@@ -51,6 +57,8 @@ exports[`classes class-convert-calling-super-apply.controller.js 1`] = `
 
 exports[`classes class-convert-constructor-keep-annot.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("fixtures.classes.MyController", {
     constructor: function constructor(arg) {
       console.log("before super");
@@ -75,6 +83,8 @@ exports[`classes class-convert-constructor-keep-annot.controller.js 1`] = `
 
 exports[`classes class-convert-constructor-keep-default.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("fixtures.classes.MyController", {
     constructor: function _constructor(arg) {
       console.log("before super");
@@ -94,6 +104,8 @@ exports[`classes class-convert-constructor-keep-default.controller.js 1`] = `
 
 exports[`classes class-convert-constructor-move.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("fixtures.classes.MyController", {
     onInit: function onInit() {
       this.other = 1;
@@ -137,12 +149,16 @@ exports[`classes class-convert-constructor-spread.js 1`] = `
 
 exports[`classes class-convert-controller-basic.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (SAPController) {
+  "use strict";
+
   const MyController = SAPController.extend("fixtures.classes.MyController", {});
 });"
 `;
 
 exports[`classes class-convert-controller-extend-static-assign.js 1`] = `
 "sap.ui.define(["sap/SAPController"], function (SAPController) {
+  "use strict";
+
   const MyController = SAPController.extend("test.fixtures.classes.MyController", {
     metadata: meta,
     renderer: {},
@@ -159,6 +175,8 @@ exports[`classes class-convert-controller-extend-static-assign.js 1`] = `
 
 exports[`classes class-convert-controller-extend-static-prop.controller.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPController) {
+  "use strict";
+
   const Formatter = {};
   const MyController = SAPController.extend("fixtures.classes.MyController", {
     metadata: {}
@@ -170,6 +188,8 @@ exports[`classes class-convert-controller-extend-static-prop.controller.js 1`] =
 
 exports[`classes class-convert-controller-extension-static-prop.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/mvc/ControllerExtension"], function (ControllerExtension) {
+  "use strict";
+
   const MyExtension = ControllerExtension.extend("fixtures.classes.MyExtension", {
     overrides: {
       onPageReady: function () {}
@@ -181,6 +201,8 @@ exports[`classes class-convert-controller-extension-static-prop.controller.js 1`
 
 exports[`classes class-convert-controller-extension-static-prop-compatibility.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/mvc/ControllerExtension"], function (ControllerExtension) {
+  "use strict";
+
   const MyExtension = ControllerExtension.extend("fixtures.classes.MyExtension", {
     override: {
       onPageReady: function () {}
@@ -192,6 +214,8 @@ exports[`classes class-convert-controller-extension-static-prop-compatibility.co
 
 exports[`classes class-convert-controller-multi.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller", "other"], function (SAPController, __Other) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -204,6 +228,8 @@ exports[`classes class-convert-controller-multi.controller.js 1`] = `
 
 exports[`classes class-convert-controller-w-oninit.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("test.fixtures.classes.MyController", {
     constructor: function _constructor(arg) {
       console.log("constructor");
@@ -229,6 +255,8 @@ exports[`classes class-convert-controller-w-oninit.controller.js 1`] = `
 
 exports[`classes class-convert-controller-wo-oninit.controller.js 1`] = `
 "sap.ui.define(["sap/ui/core/Controller"], function (Controller) {
+  "use strict";
+
   const MyController = Controller.extend("test.fixtures.classes.MyController", {
     constructor: function _constructor(arg) {
       console.log("constructor");
@@ -247,6 +275,8 @@ exports[`classes class-convert-controller-wo-oninit.controller.js 1`] = `
 
 exports[`classes class-convert-dec-alias.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.Z", {});
   return MyClass;
 });"
@@ -254,6 +284,8 @@ exports[`classes class-convert-dec-alias.js 1`] = `
 
 exports[`classes class-convert-dec-name.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.Z", {});
   return MyClass;
 });"
@@ -261,6 +293,8 @@ exports[`classes class-convert-dec-name.js 1`] = `
 
 exports[`classes class-convert-dec-namespace.controller.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.MyClass", {});
   return MyClass;
 });"
@@ -268,6 +302,8 @@ exports[`classes class-convert-dec-namespace.controller.js 1`] = `
 
 exports[`classes class-convert-dec-nonui5.js 1`] = `
 "sap.ui.define(["other/NotSAPClass"], function (__NotSAPClass) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -280,6 +316,8 @@ exports[`classes class-convert-dec-nonui5.js 1`] = `
 
 exports[`classes class-convert-extend-managed.js 1`] = `
 "sap.ui.define(["sap/ui/core/SAPClass", "./Relative"], function (SAPClass, __Relative) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -331,6 +369,8 @@ exports[`classes class-convert-extend-managed.js 1`] = `
 
 exports[`classes class-convert-file-namespace.controller.controller.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("fixtures.classes.MyClass", {});
   return MyClass;
 });"
@@ -338,6 +378,8 @@ exports[`classes class-convert-file-namespace.controller.controller.js 1`] = `
 
 exports[`classes class-convert-file-namespace-prefixed.controller.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("prefix.fixtures.classes.MyClass", {});
   return MyClass;
 });"
@@ -345,6 +387,8 @@ exports[`classes class-convert-file-namespace-prefixed.controller.js 1`] = `
 
 exports[`classes class-convert-jsdoc-alias.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.Z", {});
   return MyClass;
 });"
@@ -352,6 +396,8 @@ exports[`classes class-convert-jsdoc-alias.js 1`] = `
 
 exports[`classes class-convert-jsdoc-name.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.Z", {});
   return MyClass;
 });"
@@ -359,6 +405,8 @@ exports[`classes class-convert-jsdoc-name.js 1`] = `
 
 exports[`classes class-convert-jsdoc-namespace.controller.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.MyClass", {});
   return MyClass;
 });"
@@ -366,6 +414,8 @@ exports[`classes class-convert-jsdoc-namespace.controller.js 1`] = `
 
 exports[`classes class-convert-jsdoc-namespace.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("x.y.MyClass", {});
   return MyClass;
 });"
@@ -373,6 +423,8 @@ exports[`classes class-convert-jsdoc-namespace.js 1`] = `
 
 exports[`classes class-convert-jsdoc-nonui5.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   class MyClass extends SAPClass {}
   return MyClass;
 });"
@@ -380,6 +432,8 @@ exports[`classes class-convert-jsdoc-nonui5.js 1`] = `
 
 exports[`classes class-convert-metadata-assign.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("test.fixtures.classes.MyClass", {
     metadata: meta,
     renderer: {}
@@ -410,6 +464,8 @@ exports[`classes class-convert-metadata-assign-nested.js 1`] = `
 
 exports[`classes class-convert-metadata-prop.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Formatter = {};
   const mdata = {};
   const MyClass = SAPClass.extend("test.fixtures.classes.MyClass", {
@@ -425,6 +481,8 @@ exports[`classes class-convert-metadata-prop.js 1`] = `
 
 exports[`classes class-convert-metadata-static.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Formatter = Formatter;
   const mdata = {};
   const MyClass = SAPClass.extend("test.fixtures.classes.MyClass", {
@@ -467,6 +525,8 @@ exports[`classes class-convert-nonui5-return.js 1`] = `
 
 exports[`classes class-convert-only-move-this-binding.js 1`] = `
 "sap.ui.define(["./lib/util", "sap/ui/core/mvc/Controller"], function (Util, Controller) {
+  "use strict";
+
   const AppController = Controller.extend("app.AppController", {
     constructor: function constructor() {
       Controller.prototype.constructor.apply(this, arguments);
@@ -568,6 +628,8 @@ exports[`classes class-fix-with-existing-define.js 1`] = `
 
 exports[`classes class-import-meta.js 1`] = `
 "sap.ui.define(["require", "module", "sap/SAPClass"], function (require, module, SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("test.fixtures.classes.MyClass", {
     myUrl: function _myUrl() {
       return module.url;
@@ -603,6 +665,8 @@ exports[`comments copyright.js 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Levels = SAPClass["Levels"];
   /**
    * @name test.fixtures.libs.MyClass
@@ -618,6 +682,8 @@ exports[`comments copyright-file.js 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   // some imports
   const Levels = SAPClass["Levels"];
   /**
@@ -634,6 +700,8 @@ exports[`comments copyright-multiple-comments.js 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   /**
    * Some other comment
    */
@@ -652,6 +720,8 @@ exports[`comments min-wrap-no-import-copyright.js 1`] = `
  * \${copyright}
  */
 sap.ui.define([], function () {
+  "use strict";
+
   const x = 1; // This should be part of sap-ui-define
   return x;
 });"
@@ -689,6 +759,8 @@ sap.ui.define(["sap/m/Button"], function (Button) {
 
 exports[`decorators mixin.js 1`] = `
 "sap.ui.define(["sap/ui/core/mvc/Controller", "../lib/decorators", "../lib/RoutingSupport"], function (Controller, ___lib_decorators, __RoutingSupport) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -702,6 +774,8 @@ exports[`decorators mixin.js 1`] = `
 
 exports[`decorators mixin_mixed.js 1`] = `
 "sap.ui.define(["sap/ui/core/mvc/Controller", "../lib/decorators", "../lib/RoutingSupport"], function (Controller, ___lib_decorators, __RoutingSupport) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -718,6 +792,8 @@ exports[`empty empty_ts.ts 1`] = `""`;
 
 exports[`examples Animal.js 1`] = `
 "sap.ui.define(["sap/ui/base/ManagedObject"], function (ManagedObject) {
+  "use strict";
+
   const Animal = ManagedObject.extend("examples.Animal", {
     metadata: {
       properties: {
@@ -746,6 +822,8 @@ exports[`examples Animal.js 1`] = `
 
 exports[`examples Cat.js 1`] = `
 "sap.ui.define(["./Animal"], function (__Animal) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -772,6 +850,8 @@ exports[`examples Cat.js 1`] = `
 
 exports[`examples MyError.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   class MyError extends Error {
     constructor(msg) {
       super(msg);
@@ -784,6 +864,8 @@ exports[`examples MyError.js 1`] = `
 
 exports[`examples Utils.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function multiply(a, b) {
     return a * b;
   }
@@ -800,6 +882,8 @@ exports[`examples Utils.js 1`] = `
 
 exports[`export-collapse _extends-literal.js 1`] = `
 "sap.ui.define(["x"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -820,6 +904,8 @@ exports[`export-collapse _extends-literal.js 1`] = `
 
 exports[`export-collapse _extends-variable.js 1`] = `
 "sap.ui.define(["x"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -846,6 +932,8 @@ exports[`export-collapse _extends-variable.js 1`] = `
 
 exports[`export-collapse add-props-obj.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function one() {}
   function two() {}
   const X = {
@@ -860,6 +948,8 @@ exports[`export-collapse add-props-obj.js 1`] = `
 
 exports[`export-collapse object.assign-literal.js 1`] = `
 "sap.ui.define(["x"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -882,6 +972,8 @@ exports[`export-collapse object.assign-literal.js 1`] = `
 
 exports[`export-collapse object.assign-variable.js 1`] = `
 "sap.ui.define(["x"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -919,6 +1011,8 @@ exports[`export-error error-obj-prop.js 1`] = `"Unsafe mixing of conflicting def
 
 exports[`export-mixed export-mixed-anon-func.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = function () {
     console.log("I am the default");
   };
@@ -930,6 +1024,8 @@ exports[`export-mixed export-mixed-anon-func.js 1`] = `
 
 exports[`export-mixed export-mixed-arrow.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = () => {
     return 1;
   };
@@ -941,6 +1037,8 @@ exports[`export-mixed export-mixed-arrow.js 1`] = `
 
 exports[`export-mixed export-mixed-literal.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const a = 1;
   const b = 2;
   var __exports = {
@@ -957,6 +1055,8 @@ exports[`export-mixed export-mixed-literal.js 1`] = `
 
 exports[`export-mixed export-mixed-named-func.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function def() {
     console.log("I am the default");
   }
@@ -970,6 +1070,8 @@ exports[`export-mixed export-mixed-named-func.js 1`] = `
 
 exports[`exports export-class.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function hello() {
     return "hey";
   }
@@ -985,6 +1087,8 @@ exports[`exports export-class.js 1`] = `
 
 exports[`exports export-class-extend-native.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   class MyError extends Error {
     constructor(m) {
       super(m);
@@ -998,6 +1102,8 @@ exports[`exports export-class-extend-native.js 1`] = `
 
 exports[`exports export-default-anon-function.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   let one = 1;
   var __exports = async function () {
     return (await one) + two;
@@ -1009,6 +1115,8 @@ exports[`exports export-default-anon-function.js 1`] = `
 
 exports[`exports export-default-arrow-function.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   let one = 1;
   var __exports = () => {
     return one + two;
@@ -1020,6 +1128,8 @@ exports[`exports export-default-arrow-function.js 1`] = `
 
 exports[`exports export-default-identifier.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const x = {};
   x.a = 1;
   return x;
@@ -1028,6 +1138,8 @@ exports[`exports export-default-identifier.js 1`] = `
 
 exports[`exports export-default-named-function.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   let one = 1;
   function add() {
     return one + two + this.x;
@@ -1040,6 +1152,8 @@ exports[`exports export-default-named-function.js 1`] = `
 
 exports[`exports export-multiple.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const thing1 = {};
   const thing2 = 2;
   const thingy3 = 3;
@@ -1069,6 +1183,8 @@ exports[`exports export-multiple.js 1`] = `
 
 exports[`exports export-named-as-default.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const one = 1;
   var __exports = {
     __esModule: true
@@ -1080,6 +1196,8 @@ exports[`exports export-named-as-default.js 1`] = `
 
 exports[`exports export-named-from.js 1`] = `
 "sap.ui.define(["A", "path/having-dash"], function (__A, __path_having_dash) {
+  "use strict";
+
   var __exports = {
     __esModule: true
   };
@@ -1093,6 +1211,8 @@ exports[`exports export-named-from.js 1`] = `
 
 exports[`exports export-obj.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function getFoo() {
     return 1;
   }
@@ -1109,6 +1229,8 @@ exports[`exports export-obj.js 1`] = `
 
 exports[`flow flow-exports.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Foo = SAPClass.extend("Foo", {});
   return Foo;
 });"
@@ -1116,14 +1238,22 @@ exports[`flow flow-exports.js 1`] = `
 
 exports[`imports import-all.js 1`] = `
 "sap.ui.define(["G"], function (G) {
+  "use strict";
+
   return G;
 });"
 `;
 
-exports[`imports import-at-sign.js 1`] = `"sap.ui.define(["@babel/polyfill", "dash-separated"], function (___babel_polyfill, __dash_separated) {});"`;
+exports[`imports import-at-sign.js 1`] = `
+"sap.ui.define(["@babel/polyfill", "dash-separated"], function (___babel_polyfill, __dash_separated) {
+  "use strict";
+});"
+`;
 
 exports[`imports import-duplicate-src-1.js 1`] = `
 "sap.ui.define(["X"], function (XA) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1135,6 +1265,8 @@ exports[`imports import-duplicate-src-1.js 1`] = `
 
 exports[`imports import-duplicate-src-2.js 1`] = `
 "sap.ui.define(["X"], function (__XD) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1147,6 +1279,8 @@ exports[`imports import-duplicate-src-2.js 1`] = `
 
 exports[`imports import-duplicate-src-3.js 1`] = `
 "sap.ui.define(["X"], function (__XD) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1159,6 +1293,8 @@ exports[`imports import-duplicate-src-3.js 1`] = `
 
 exports[`imports import-dynamic.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   function __ui5_require_async(path) {
     return new Promise(function (resolve, reject) {
       sap.ui.require([path], function (module) {
@@ -1190,6 +1326,8 @@ exports[`imports import-dynamic.js 1`] = `
 
 exports[`imports import-modules-map.js 1`] = `
 "sap.ui.define(["./vendor/browser-polyfill"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1202,6 +1340,8 @@ exports[`imports import-modules-map.js 1`] = `
 
 exports[`imports import-modules-map-fn.js 1`] = `
 "sap.ui.define(["./vendor/browser-polyfill"], function (__X) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1214,6 +1354,8 @@ exports[`imports import-modules-map-fn.js 1`] = `
 
 exports[`imports import-multiple.js 1`] = `
 "sap.ui.define(["./../a/b", "path/having-dash", "A", "BC", "DEF", "G", "HI"], function (____a_b, __path_having_dash, __A, __BC, __D, G, __H) {
+  "use strict";
+
   function _interopRequireDefault(obj) {
     return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
   }
@@ -1231,6 +1373,8 @@ exports[`imports import-multiple.js 1`] = `
 exports[`libs libs-other-imports.js 1`] = `
 "import _ from "lodash";
 sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Levels = SAPClass["Levels"];
   const MyClass = SAPClass.extend("test.fixtures.libs.MyClass", {});
   MyClass.Levels = Levels;
@@ -1240,6 +1384,8 @@ sap.ui.define(["sap/SAPClass"], function (SAPClass) {
 
 exports[`libs libs-sap-imports.js 1`] = `
 "sap.ui.define(["sap/SAPClass"], function (SAPClass) {
+  "use strict";
+
   const Levels = SAPClass["Levels"];
   const MyClass = SAPClass.extend("test.fixtures.libs.MyClass", {});
   MyClass.Levels = Levels;
@@ -1249,6 +1395,8 @@ exports[`libs libs-sap-imports.js 1`] = `
 
 exports[`libs libs-sap-imports-dashes.js 1`] = `
 "sap.ui.define(["sap/SAPClass-with-dashes"], function (SAPClassDashes) {
+  "use strict";
+
   const Levels = SAPClassDashes["Levels"];
   const MyClass = SAPClassDashes.extend("test.fixtures.libs.MyClass", {});
   MyClass.Levels = Levels;
@@ -1258,6 +1406,8 @@ exports[`libs libs-sap-imports-dashes.js 1`] = `
 
 exports[`min-wrap min-wrap-no-import.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const x = 1;
   return x;
 });"
@@ -1289,6 +1439,8 @@ sap.ui.define(["sap/m/Button"], function (Button) {
 
 exports[`mixed mixed-import-export.js 1`] = `
 "sap.ui.define(["1", "2", "3", "4", "5"], function (__1, __2, __3, __4, __5) {
+  "use strict";
+
   var __exports = {
     __esModule: true
   };
@@ -1313,6 +1465,21 @@ exports[`mixed mixed-import-export.js 1`] = `
 });"
 `;
 
+exports[`never-use-strict use-strict-define.js 1`] = `
+"sap.ui.define(["sap/m/Button"], function (Button) {
+  const b = new Button();
+  return b;
+});"
+`;
+
+exports[`never-use-strict use-strict-program.js 1`] = `
+"const x = 1;
+sap.ui.define(["sap/m/Button"], function (Button) {
+  const b = new Button();
+  return b;
+});"
+`;
+
 exports[`no-wrap nowrap-existing-sap.ui.define.js 1`] = `
 "sap.ui.define(["JSONModel"], JSONModel => {
   return new JSONModel();
@@ -1327,6 +1494,8 @@ exports[`no-wrap skip-iffe.js 1`] = `
 
 exports[`preset-env preset-env-class.js 1`] = `
 "sap.ui.define(["sap/class"], function (SAPClass) {
+  "use strict";
+
   var MyClass = SAPClass.extend("my.MyClass", {
     constructor: function constructor() {
       SAPClass.prototype.constructor.apply(this, arguments);
@@ -1346,6 +1515,8 @@ exports[`preset-env preset-env-class.js 1`] = `
 
 exports[`preset-env preset-env-property-mutators.js 1`] = `
 "sap.ui.define(["sap/class", "core-js/modules/es6.object.define-properties.js"], function (SAPClass, __core_js_modules_es6objectdefine_propertiesjs) {
+  "use strict";
+
   var MyClass = SAPClass.extend("my.MyClass", Object.defineProperties({}, {
     thing: {
       get: function get() {
@@ -1364,6 +1535,8 @@ exports[`preset-env preset-env-property-mutators.js 1`] = `
 
 exports[`preset-env preset-env-usage.js 1`] = `
 "sap.ui.define(["sap/SAPClass", "core-js/modules/es6.object.to-string.js"], function (SAPClass, __core_js_modules_es6objectto_stringjs) {
+  "use strict";
+
   import "core-js/modules/es6.promise.js";
   import "core-js/modules/es6.string.includes.js";
   import "core-js/modules/es7.array.includes.js";
@@ -1383,6 +1556,8 @@ exports[`preset-env preset-env-usage.js 1`] = `
 
 exports[`typescript ts-class-anonymous.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("MyClass", {
     createAnonymousClass: function _createAnonymousClass() {
       return new class {
@@ -1399,6 +1574,8 @@ exports[`typescript ts-class-anonymous-copyright.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1420,6 +1597,8 @@ exports[`typescript ts-class-anonymous-copyright-file.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1438,6 +1617,8 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
 
 exports[`typescript ts-class-param-props.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("MyClass", {
     constructor: function _constructor(bar, x, y) {
       SAPClass.prototype.constructor.call(this);
@@ -1456,6 +1637,8 @@ exports[`typescript ts-class-param-props-copyright.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1477,6 +1660,8 @@ exports[`typescript ts-class-param-props-copyright-file.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1495,6 +1680,8 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
 
 exports[`typescript ts-class-props.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("MyClass", {
     constructor: function constructor() {
       SAPClass.prototype.constructor.apply(this, arguments);
@@ -1511,6 +1698,8 @@ exports[`typescript ts-class-props.ts 1`] = `
 
 exports[`typescript ts-class-props-only-move-this.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   const MyClass = SAPClass.extend("MyClass", {
     S: "S",
     PS: "PS",
@@ -1524,6 +1713,8 @@ exports[`typescript ts-class-props-only-move-this.ts 1`] = `
 
 exports[`typescript ts-export-default-typed-anon-fn-only-default.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = function (date) {
     return "";
   };
@@ -1533,6 +1724,8 @@ exports[`typescript ts-export-default-typed-anon-fn-only-default.ts 1`] = `
 
 exports[`typescript ts-export-default-typed-anon-obj.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = {
     x: 1
   };
@@ -1542,6 +1735,8 @@ exports[`typescript ts-export-default-typed-anon-obj.ts 1`] = `
 
 exports[`typescript ts-export-default-typed-arrow-fn-only-default.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const fn = date => {
     return "";
   };
@@ -1554,6 +1749,8 @@ exports[`typescript ts-export-default-typed-arrow-fn-only-default.ts 1`] = `
 
 exports[`typescript ts-export-default-typed-arrow-fn-with-named.1.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const fn = date => {
     return "";
   };
@@ -1567,6 +1764,8 @@ exports[`typescript ts-export-default-typed-arrow-fn-with-named.1.ts 1`] = `
 
 exports[`typescript ts-export-interface.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const MY_CONSTANT = "constant";
   var MyEnum = function (MyEnum) {
     MyEnum[MyEnum["A"] = 0] = "A";
@@ -1586,6 +1785,8 @@ exports[`typescript ts-export-interface.ts 1`] = `
 
 exports[`typescript ts-export-type.ts 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   class Class {}
   var __exports = {
     __esModule: true
@@ -1597,6 +1798,8 @@ exports[`typescript ts-export-type.ts 1`] = `
 
 exports[`typescript-preset-env ts-class-anonymous.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   import "core-js/modules/es6.symbol.js";
   import "core-js/modules/es6.number.constructor.js";
   function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
@@ -1628,6 +1831,8 @@ exports[`typescript-preset-env ts-class-anonymous-copyright.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   import "core-js/modules/es6.symbol.js";
   import "core-js/modules/es6.number.constructor.js";
   function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
@@ -1664,6 +1869,8 @@ exports[`typescript-preset-env ts-class-anonymous-copyright-file.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   import "core-js/modules/es6.symbol.js";
   import "core-js/modules/es6.number.constructor.js";
   function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
@@ -1697,6 +1904,8 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
 
 exports[`typescript-preset-env ts-class-param-props.ts 1`] = `
 "sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   var MyClass = SAPClass.extend("MyClass", {
     constructor: function _constructor(bar, x, y) {
       SAPClass.prototype.constructor.call(this);
@@ -1715,6 +1924,8 @@ exports[`typescript-preset-env ts-class-param-props-copyright.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1736,6 +1947,8 @@ exports[`typescript-preset-env ts-class-param-props-copyright-file.ts 1`] = `
  * \${copyright}
  */
 sap.ui.define(["sap/Class"], function (SAPClass) {
+  "use strict";
+
   /**
    * @name MyClass
    */
@@ -1754,6 +1967,8 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
 
 exports[`wrapping export-const.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   const X = {};
   return X;
 });"
@@ -1761,6 +1976,8 @@ exports[`wrapping export-const.js 1`] = `
 
 exports[`wrapping export-jsdoc-global.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = {};
   return __exports;
 }, true);"
@@ -1768,6 +1985,8 @@ exports[`wrapping export-jsdoc-global.js 1`] = `
 
 exports[`wrapping export-literal.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = {};
   return __exports;
 });"
@@ -1775,6 +1994,8 @@ exports[`wrapping export-literal.js 1`] = `
 
 exports[`wrapping export-options-global.js 1`] = `
 "sap.ui.define([], function () {
+  "use strict";
+
   var __exports = {};
   return __exports;
 }, true);"

--- a/packages/plugin/__test__/fixtures/never-use-strict/use-strict-define.js
+++ b/packages/plugin/__test__/fixtures/never-use-strict/use-strict-define.js
@@ -1,0 +1,5 @@
+import Button from "sap/m/Button";
+
+const b = new Button();
+
+export default b;

--- a/packages/plugin/__test__/fixtures/never-use-strict/use-strict-program.js
+++ b/packages/plugin/__test__/fixtures/never-use-strict/use-strict-program.js
@@ -1,0 +1,7 @@
+const x = 1; // This should not be part of sap-ui-define
+
+import Button from "sap/m/Button";
+
+const b = new Button();
+
+export default b;

--- a/packages/plugin/__test__/options.js
+++ b/packages/plugin/__test__/options.js
@@ -64,6 +64,10 @@ const Options = {
     "min-wrap": {
       noWrapBeforeImport: true,
     },
+    "never-use-strict": {
+      noWrapBeforeImport: true,
+      neverUseStrict: true,
+    },
     _private_: {
       noWrapBeforeImport: true,
       moveControllerPropsToOnInit: true,


### PR DESCRIPTION
The `"use strict"` directive should also be added to each `sap.ui.define` callback function. Only in case the directive is present on the program node, it will not be added. The addition of the directive can be supressed with the option `neverUseStrict`.

Fixes #113