### PR TITLE
feat: support using predefined controller extensions

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -819,6 +819,20 @@ exports[`decorators mixin_mixed.js 1`] = `
 });"
 `;
 
+exports[`decorators ts-class-controller-extension-usage-decorator.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/fe/core/controllerextensions/Routing"], function (Controller, Routing) {
+  "use strict";
+
+  /**
+   * @namespace test.controller
+   */
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    routing: Routing
+  });
+  return MyExtendedController;
+});"
+`;
+
 exports[`empty empty_js.js 1`] = `""`;
 
 exports[`empty empty_ts.ts 1`] = `""`;
@@ -1645,6 +1659,38 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
     }
   });
   return MyClass;
+});"
+`;
+
+exports[`typescript ts-class-controller-extension-usage.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/fe/core/controllerextensions/Routing", "sap/fe/core/controllerextensions/OtherExtension", "sap/fe/core/controllerextensions/ThirdExtension", "sap/fe/core/controllerextensions/DoubleExportExtension", "sap/fe/core/controllerextensions/ManyExtensions"], function (Controller, Routing, sap_fe_core_controllerextensions_OtherExtension, ThirdExtension, sap_fe_core_controllerextensions_DoubleExportExtension, extensionCollection) {
+  "use strict";
+
+  const OtherExtension = sap_fe_core_controllerextensions_OtherExtension["OtherExtension"];
+  const SomethingElse = sap_fe_core_controllerextensions_DoubleExportExtension["SomethingElse"];
+  const AlmostRemovedExtension = sap_fe_core_controllerextensions_DoubleExportExtension["AlmostRemovedExtension"];
+  /**
+   * @namespace test.controller
+   */
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    // @transformControllerExtension
+    fifth: extensionCollection.group.OneOfManyExtensions,
+    // @transformControllerExtension
+    fourth: AlmostRemovedExtension,
+    // @transformControllerExtension
+    third: ThirdExtension,
+    // @transformControllerExtension
+    other: OtherExtension,
+    /**
+     * @transformControllerExtension
+     */
+    routing: Routing,
+    constructor: function _constructor() {
+      Controller.prototype.constructor.call(this);
+      this.realPropertyExtension = SomethingElse.Something;
+    }
+  });
+  return MyExtendedController;
 });"
 `;
 

--- a/packages/plugin/__test__/fixtures/decorators/ts-class-controller-extension-usage-decorator.ts
+++ b/packages/plugin/__test__/fixtures/decorators/ts-class-controller-extension-usage-decorator.ts
@@ -1,0 +1,12 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+
+	@transformControllerExtension
+	routing: Routing;
+
+}

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-usage.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-usage.ts
@@ -1,0 +1,37 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+import { OtherExtension } from "sap/fe/core/controllerextensions/OtherExtension";
+import * as ThirdExtension from "sap/fe/core/controllerextensions/ThirdExtension";
+import { SomethingElse, AlmostRemovedExtension } from "sap/fe/core/controllerextensions/DoubleExportExtension";
+import * as extensionCollection from "sap/fe/core/controllerextensions/ManyExtensions";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+
+	/**
+	 * @transformControllerExtension
+	 */
+	routing: Routing;
+
+	// @transformControllerExtension
+	other: OtherExtension;
+
+	// @transformControllerExtension
+	third: ThirdExtension;
+
+	// @transformControllerExtension
+	fourth: AlmostRemovedExtension;
+
+	// @transformControllerExtension
+	fifth: extensionCollection.group.OneOfManyExtensions;
+
+	realPropertyExtension;
+
+	constructor() {
+		super();
+
+		this.realPropertyExtension = SomethingElse.Something;
+	}
+}

--- a/packages/plugin/__test__/test.js
+++ b/packages/plugin/__test__/test.js
@@ -75,7 +75,7 @@ function processDirectory(dir) {
             presets,
             sourceRoot: __dirname,
             comments:
-              filePath.includes("comments") || filename.includes("copyright"),
+              filePath.includes("comments") || filename.includes("copyright") || filename.includes("controller-extension-usage"),
             babelrc: false,
           }).code;
 

--- a/packages/plugin/src/classes/helpers/imports.js
+++ b/packages/plugin/src/classes/helpers/imports.js
@@ -1,0 +1,39 @@
+import { types as t } from "@babel/core";
+
+let importDeclarations = {};
+
+export const saveImports = (file) => {
+  // save all import declarations before "unneeded" ones are removed by the TypeScript plugin
+  importDeclarations[file.opts.filename] = file.ast.program.body.filter(
+    t.isImportDeclaration
+  ); // right now even the removed import still exists later and can be re-added. Otherwise do: .map(decl => t.cloneNode(decl));
+};
+
+// can be called from visitor to access previously present declarations
+export function getImportDeclaration(filename, typeName) {
+  const typeNameParts = typeName.split(".");
+
+  // find the declaration importing the typeName among the collected import declarations in this file
+  const filteredDeclarations = importDeclarations[filename].filter(
+    (importDeclaration) => {
+      // each import declaration can import several entities, so let's check all of them
+      for (let specifier of importDeclaration.specifiers) {
+        if (
+          (t.isImportDefaultSpecifier(specifier) ||
+            t.isImportNamespaceSpecifier(specifier)) &&
+          specifier.local.name === typeNameParts[0]
+        ) {
+          // if the import is default, then the typeName should only have one part (the import name)
+          return true;
+        } else if (
+          t.isImportSpecifier(specifier) &&
+          specifier.imported.name === typeNameParts[typeNameParts.length - 1]
+        ) {
+          // If the import is named, then the last part of the typeName should match the imported name
+          return true;
+        }
+      }
+    }
+  );
+  return filteredDeclarations[0]; // should be exactly one
+}

--- a/packages/plugin/src/classes/pre.js
+++ b/packages/plugin/src/classes/pre.js
@@ -1,0 +1,6 @@
+import { saveImports } from "./helpers/imports";
+
+export const ClassPre = (file) => {
+  // save all import declarations before "unneeded" ones are removed by the TypeScript plugin
+  saveImports(file);
+};

--- a/packages/plugin/src/classes/visitor.js
+++ b/packages/plugin/src/classes/visitor.js
@@ -6,6 +6,9 @@ import * as classes from "./helpers/classes";
 const CONSTRUCTOR = "constructor";
 
 export const ClassTransformVisitor = {
+  ImportDeclaration(path) {
+    this.importDeclarationPaths.push(path);
+  },
   ImportDefaultSpecifier(path) {
     this.importNames.push(path.node.local.name);
   },
@@ -71,6 +74,7 @@ export const ClassTransformVisitor = {
         node,
         classInfo,
         staticProps,
+        this.importDeclarationPaths,
         opts
       );
 

--- a/packages/plugin/src/index.js
+++ b/packages/plugin/src/index.js
@@ -1,4 +1,5 @@
 import { ClassTransformVisitor } from "./classes/visitor";
+import { ClassPre } from "./classes/pre";
 import { ModuleTransformVisitor } from "./modules/visitor";
 
 import { wrap } from "./modules/helpers/wrapper";
@@ -48,6 +49,7 @@ module.exports = () => {
 
         // Properties for Class Transform
         this.importNames = [];
+        this.importDeclarationPaths = [];
 
         // The classes must be converted right away before any other class transforms get a chance to run.
         path.traverse(ClassTransformVisitor, this);
@@ -62,6 +64,7 @@ module.exports = () => {
   };
 
   return {
+    pre: ClassPre,
     visitor: UI5Visitor,
   };
 };


### PR DESCRIPTION
When using a controller extension in your own controller as a kind of mix-in, UI5 currently expects in the "extend" config object the extension class to be assigned to a property.

In TypeScript, however, the TS compiler must see the property being typed with an *instance* of the extension class, so subsequent calls to the extension can be written like they should
(this.routing.doSomething()).

This change introduces the "@transformControllerExtension" comment and decorator which triggers a special kind of transformation for annotated class properties. The controller extension type assigned to the subsequent class property is then assigned as class in the extend object in JavaScript. And this assignment is not moved into the constructor like it normally would be.

Fixes https://github.com/SAP/ui5-typescript/issues/420