### PR TITLE
fix: support index modules for dependencies

### DIFF
--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1492,7 +1492,7 @@ exports[`mixed mixed-import-export.js 1`] = `
     __esModule: true
   };
   function extendExports(exports, obj) {
-    Object.keys(obj).forEach(function (key) {
+    obj && Object.keys(obj).forEach(function (key) {
       if (key === "default" || key === "__esModule") return;
       Object.defineProperty(exports, key, {
         enumerable: true,
@@ -1875,6 +1875,31 @@ exports[`typescript ts-export-type.ts 1`] = `
 });"
 `;
 
+exports[`typescript ts-export-type-only.ts 1`] = `""`;
+
+exports[`typescript ts-index.ts 1`] = `
+"sap.ui.define(["./_private_/index"], function (____private__index) {
+  "use strict";
+
+  var __exports = {
+    __esModule: true
+  };
+  function extendExports(exports, obj) {
+    obj && Object.keys(obj).forEach(function (key) {
+      if (key === "default" || key === "__esModule") return;
+      Object.defineProperty(exports, key, {
+        enumerable: true,
+        get: function get() {
+          return obj[key];
+        }
+      });
+    });
+  }
+  extendExports(__exports, ____private__index);
+  return __exports;
+});"
+`;
+
 exports[`typescript ts-re-export.ts 1`] = `
 "sap.ui.define(["module", "./having-a-dash", "path/having-a-dash"], function (__module, ___having_a_dash, __path_having_a_dash) {
   "use strict";
@@ -1883,7 +1908,7 @@ exports[`typescript ts-re-export.ts 1`] = `
     __esModule: true
   };
   function extendExports(exports, obj) {
-    Object.keys(obj).forEach(function (key) {
+    obj && Object.keys(obj).forEach(function (key) {
       if (key === "default" || key === "__esModule") return;
       Object.defineProperty(exports, key, {
         enumerable: true,
@@ -1896,6 +1921,29 @@ exports[`typescript ts-re-export.ts 1`] = `
   extendExports(__exports, __module);
   extendExports(__exports, ___having_a_dash);
   extendExports(__exports, __path_having_a_dash);
+  return __exports;
+});"
+`;
+
+exports[`typescript ts-re-export-type-only.ts 1`] = `
+"sap.ui.define(["./ts-export-type-only"], function (___ts_export_type_only) {
+  "use strict";
+
+  var __exports = {
+    __esModule: true
+  };
+  function extendExports(exports, obj) {
+    obj && Object.keys(obj).forEach(function (key) {
+      if (key === "default" || key === "__esModule") return;
+      Object.defineProperty(exports, key, {
+        enumerable: true,
+        get: function get() {
+          return obj[key];
+        }
+      });
+    });
+  }
+  extendExports(__exports, ___ts_export_type_only);
   return __exports;
 });"
 `;

--- a/packages/plugin/__test__/fixtures/typescript/_private_/index.ts
+++ b/packages/plugin/__test__/fixtures/typescript/_private_/index.ts
@@ -1,0 +1,1 @@
+export * from "./type";

--- a/packages/plugin/__test__/fixtures/typescript/_private_/type.ts
+++ b/packages/plugin/__test__/fixtures/typescript/_private_/type.ts
@@ -1,0 +1,1 @@
+export type StringOrBoolean = string | boolean;

--- a/packages/plugin/__test__/fixtures/typescript/ts-export-type-only.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-export-type-only.ts
@@ -1,0 +1,4 @@
+/**
+ * any sequence of octets
+ */
+export type Binary = any;

--- a/packages/plugin/__test__/fixtures/typescript/ts-index.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-index.ts
@@ -1,0 +1,1 @@
+export * from "./_private_";

--- a/packages/plugin/__test__/fixtures/typescript/ts-re-export-type-only.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-re-export-type-only.ts
@@ -1,0 +1,1 @@
+export * from "./ts-export-type-only";

--- a/packages/plugin/src/utils/templates.js
+++ b/packages/plugin/src/utils/templates.js
@@ -50,7 +50,7 @@ export function buildNamedExport(obj) {
 
 export const buildAllExportHelper = template(`
   function extendExports(exports, obj) {
-    Object.keys(obj).forEach(function (key) {
+    obj && Object.keys(obj).forEach(function (key) {
       if (key === "default" || key === "__esModule") return;
       Object.defineProperty(exports, key, {
         enumerable: true,


### PR DESCRIPTION
CommonJS or ES modules require index modules when a folder is required, e.g.:

```js
import * from "./schema"
```

will in case of `./schema` is a directory lookup the index module and require the following:

```js
import * from "./schema/index"
```

under the hood. As the UI5 module loader cannot support this feature this Babel plugin checks for the existence of the index module and rewrites the import to the index module so that the UI5 loader also loads the proper module.