### PR TITLE
fix: remove empty export declaration added by TypeScript

### DIFF
--- a/packages/plugin/src/modules/helpers/wrapper.js
+++ b/packages/plugin/src/modules/helpers/wrapper.js
@@ -21,7 +21,16 @@ export function wrap(visitor, programNode, opts) {
     injectDynamicImportHelper
   );
 
-  if (!needsWrap) return;
+  if (!needsWrap) {
+    // cleanup the program node if it's empty (just having empty imports)
+    programNode.body = programNode.body.filter((node) => {
+      if (t.isExportNamedDeclaration(node)) {
+        return node.declaration != null;
+      }
+      return true;
+    });
+    return;
+  }
 
   let { body } = programNode;
 


### PR DESCRIPTION
The following code of the babel-plugin-transform-typescript creates an empty export for modules
https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-typescript/src/index.ts#L399