### PR TITLE
feat: support ControllerExtensions extended with .override(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,9 @@ The `overrides` class property (added in UI5 version 1.112) required for impleme
 (For backward compatibility with older UI5 runtimes, you can use `overridesToOverride: true`.)
 
 ```js
+/**
+ * @namespace my.sample
+ */
 class MyExtension extends ControllerExtension {
 
   static overrides = {
@@ -606,7 +609,7 @@ class MyExtension extends ControllerExtension {
 is converted to
 
 ```js
-const MyExtension = ControllerExtension.extend("MyExtension", {
+const MyExtension = ControllerExtension.extend("my.sample.MyExtension", {
   overrides: {
     onPageReady: function () {}
   }
@@ -623,6 +626,9 @@ Example:
 import Routing from "sap/fe/core/controllerextensions/Routing";
 import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
 
+/**
+ * @namespace my.sample
+ */
 class MyController extends Controller {
 
   routing = ControllerExtension.use(Routing); // use the "Routing" extension provided by sap.fe
@@ -638,7 +644,7 @@ is converted to the proper `Controller.extend(...)` code as expected by the UI5 
 ```js
 // ...
 
-const MyController = Controller.extend("MyController", {
+const MyController = Controller.extend("my.sample.MyController", {
   routing: Routing, // now the Routing *class* is assigned as value, while above it appeared to be an instance
   
   someMethod: function() {
@@ -648,7 +654,8 @@ const MyController = Controller.extend("MyController", {
 return MyController;
 ```
 
-> ***NOTE***: In order to have this transformer plugin recognize and remove the dummy method call, you MUST a) call it on the ControllerExtension base class (the module imported from `sap/ui/core/mvc/ControllerExtension`), not on a class deriving from it (even though it is inherited) and b) assign the extension right in the class definition as shown in the examples on this page (an "equal" sign is used, not a colon like in JavaScript, as this is now ES class syntax and not a configuration object).
+> ***NOTE***: In order to have this transformer plugin recognize and remove the dummy method call, you MUST a) call it on the ControllerExtension base class (the module imported from `sap/ui/core/mvc/ControllerExtension`), not on a class deriving from it (even though it is inherited) and b) assign the extension right in the class definition as shown in the examples on this page (an "equal" sign is used, not a colon like in JavaScript, as this is now ES class syntax and not a configuration object). Any variation may cause the call not to be recognized and removed and lead to a runtime error. Calling `ControllerExtension.use(...)` with more or less than one argument will not only cause a TypeScript error, but will also make this transformer throw an error.<br>
+The removal only takes place when the class definition overall is recognized and transformed by this transformer. So when the class still is an ES6 class in the output, first fix this, then check again whether the `ControllerExtension.use(...)` call has been removed.
 
 Some controller extensions allow implementing hooks or overriding their behavior. This can be done equally:
 
@@ -656,6 +663,9 @@ Some controller extensions allow implementing hooks or overriding their behavior
 import Routing from "sap/fe/core/controllerextensions/Routing";
 import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
 
+/**
+ * @namespace my.sample
+ */
 class MyController extends Controller {
 
   routing = ControllerExtension.use(Routing.override({
@@ -673,10 +683,10 @@ class MyController extends Controller {
 
 Since class properties are an early ES proposal, TypeScript's compiler (like babel's class properties transform) moves static properties outside the class definition, and moves instance properties inside the constructor (even if TypeScript is configured to output ESNext).
 
-To support this, the plugin will also search for static properties outside the class definition. It does not currently search in the constructor (but will in the future) so be sure to define renderer and metadata as static props if Typescript is used.
+To support this, the plugin will also search for static properties outside the class definition. It does not currently search in the constructor (but will in the future) so be sure to define renderer and metadata as static props if TypeScript is used.
 
 ```ts
-/** Typescript **/
+/** TypeScript **/
 class MyControl extends SAPClass {
     static renderer: any = MyControlRenderer;
     static metadata: any = {
@@ -684,7 +694,7 @@ class MyControl extends SAPClass {
     };
 }
 
-/** Typescript Output **/
+/** TypeScript Output **/
 class MyControl extends SAPClass {}
 MyControl.renderer = MyControlRenderer;
 MyControl.metadata = {

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1680,23 +1680,22 @@ exports[`typescript ts-class-controller-extension-extended.ts 1`] = `
   return MyExtendedController;
 });"
 `;
-
 exports[`typescript ts-class-controller-extension-extended-error-1.ts 1`] = `
 "ControllerExtension.use() must be called with exactly one argument but has 0
-[0m [90m  7 |[39m [90m */[39m[0m
-[0m [90m  8 |[39m [36mexport[39m [36mdefault[39m [36mclass[39m [33mMyExtendedController[39m [36mextends[39m [33mController[39m {[0m
-[0m[31m[1m>[22m[39m[90m  9 |[39m 	routing [33m=[39m [33mControllerExtension[39m[33m.[39muse()[33m;[39m [90m// should throw an error[39m[0m
-[0m [90m    |[39m 	[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m
-[0m [90m 10 |[39m }[0m"
+   7 |  */
+   8 | export default class MyExtendedController extends Controller {
+>  9 | 	routing = ControllerExtension.use(); // should throw an error
+     | 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 | }"
 `;
 
 exports[`typescript ts-class-controller-extension-extended-error-2.ts 1`] = `
 "ControllerExtension.use() must be called with exactly one argument but has 2
-[0m [90m  7 |[39m [90m */[39m[0m
-[0m [90m  8 |[39m [36mexport[39m [36mdefault[39m [36mclass[39m [33mMyExtendedController[39m [36mextends[39m [33mController[39m {[0m
-[0m[31m[1m>[22m[39m[90m  9 |[39m 	routing [33m=[39m [33mControllerExtension[39m[33m.[39muse([35m1[39m[33m,[39m [35m2[39m)[33m;[39m [90m// should throw an error[39m[0m
-[0m [90m    |[39m 	[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m
-[0m [90m 10 |[39m }[0m"
+   7 |  */
+   8 | export default class MyExtendedController extends Controller {
+>  9 | 	routing = ControllerExtension.use(1, 2); // should throw an error
+     | 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 | }"
 `;
 
 exports[`typescript ts-class-controller-extension-extended-explicit-type.ts 1`] = `

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1665,6 +1665,32 @@ sap.ui.define(["sap/Class"], function (SAPClass) {
 });"
 `;
 
+exports[`typescript ts-class-controller-extension-extended.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/core/mvc/ControllerExtension", "sap/fe/core/controllerextensions/Routing"], function (Controller, ControllerExtension, Routing) {
+  "use strict";
+
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    routing: Routing.override({})
+  });
+  return MyExtendedController;
+});"
+`;
+
+exports[`typescript ts-class-controller-extension-extended-explicit-type.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/core/mvc/ControllerExtension", "sap/fe/core/controllerextensions/Routing"], function (Controller, ControllerExtension, Routing) {
+  "use strict";
+
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    routing2: Routing.override({
+      x: 1,
+      fn: () => {}
+    }),
+    routing: Routing.override({})
+  });
+  return MyExtendedController;
+});"
+`;
+
 exports[`typescript ts-class-controller-extension-usage.ts 1`] = `
 "sap.ui.define(["sap/ui/core/mvc/Controller", "sap/fe/core/controllerextensions/Routing", "sap/fe/core/controllerextensions/OtherExtension", "sap/fe/core/controllerextensions/ThirdExtension", "sap/fe/core/controllerextensions/DoubleExportExtension", "sap/fe/core/controllerextensions/ManyExtensions"], function (Controller, Routing, sap_fe_core_controllerextensions_OtherExtension, ThirdExtension, sap_fe_core_controllerextensions_DoubleExportExtension, extensionCollection) {
   "use strict";
@@ -1692,6 +1718,26 @@ exports[`typescript ts-class-controller-extension-usage.ts 1`] = `
       Controller.prototype.constructor.call(this);
       this.realPropertyExtension = SomethingElse.Something;
     }
+  });
+  return MyExtendedController;
+});"
+`;
+
+exports[`typescript ts-class-controller-extension-usage-new.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/fe/core/controllerextensions/Routing", "sap/fe/core/controllerextensions/OtherExtension", "sap/fe/core/controllerextensions/ThirdExtension", "sap/fe/core/controllerextensions/DoubleExportExtension", "sap/fe/core/controllerextensions/ManyExtensions", "sap/ui/core/mvc/ControllerExtension"], function (Controller, Routing, sap_fe_core_controllerextensions_OtherExtension, ThirdExtension, sap_fe_core_controllerextensions_DoubleExportExtension, extensionCollection, ControllerExtension) {
+  "use strict";
+
+  const OtherExtension = sap_fe_core_controllerextensions_OtherExtension["OtherExtension"];
+  const AlmostRemovedExtension = sap_fe_core_controllerextensions_DoubleExportExtension["AlmostRemovedExtension"];
+  /**
+   * @namespace test.controller
+   */
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    fifth: extensionCollection.group.OneOfManyExtensions,
+    fourth: AlmostRemovedExtension,
+    third: ThirdExtension,
+    other: OtherExtension,
+    routing: Routing
   });
   return MyExtendedController;
 });"

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1670,10 +1670,33 @@ exports[`typescript ts-class-controller-extension-extended.ts 1`] = `
   "use strict";
 
   const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
+    constructor: function constructor() {
+      Controller.prototype.constructor.apply(this, arguments);
+      this.routing2 = Routing.use(Routing.override({}));
+      this.routing3 = Controller.use(Routing.override({}));
+    },
     routing: Routing.override({})
   });
   return MyExtendedController;
 });"
+`;
+
+exports[`typescript ts-class-controller-extension-extended-error-1.ts 1`] = `
+"ControllerExtension.use() must be called with exactly one argument but has 0
+[0m [90m  7 |[39m [90m */[39m[0m
+[0m [90m  8 |[39m [36mexport[39m [36mdefault[39m [36mclass[39m [33mMyExtendedController[39m [36mextends[39m [33mController[39m {[0m
+[0m[31m[1m>[22m[39m[90m  9 |[39m 	routing [33m=[39m [33mControllerExtension[39m[33m.[39muse()[33m;[39m [90m// should throw an error[39m[0m
+[0m [90m    |[39m 	[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m
+[0m [90m 10 |[39m }[0m"
+`;
+
+exports[`typescript ts-class-controller-extension-extended-error-2.ts 1`] = `
+"ControllerExtension.use() must be called with exactly one argument but has 2
+[0m [90m  7 |[39m [90m */[39m[0m
+[0m [90m  8 |[39m [36mexport[39m [36mdefault[39m [36mclass[39m [33mMyExtendedController[39m [36mextends[39m [33mController[39m {[0m
+[0m[31m[1m>[22m[39m[90m  9 |[39m 	routing [33m=[39m [33mControllerExtension[39m[33m.[39muse([35m1[39m[33m,[39m [35m2[39m)[33m;[39m [90m// should throw an error[39m[0m
+[0m [90m    |[39m 	[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m
+[0m [90m 10 |[39m }[0m"
 `;
 
 exports[`typescript ts-class-controller-extension-extended-explicit-type.ts 1`] = `
@@ -1685,6 +1708,17 @@ exports[`typescript ts-class-controller-extension-extended-explicit-type.ts 1`] 
       x: 1,
       fn: () => {}
     }),
+    routing: Routing.override({})
+  });
+  return MyExtendedController;
+});"
+`;
+
+exports[`typescript ts-class-controller-extension-extended-renamed.ts 1`] = `
+"sap.ui.define(["sap/ui/core/mvc/Controller", "sap/ui/core/mvc/ControllerExtension", "sap/fe/core/controllerextensions/Routing"], function (Controller, CtrlEx, Routing) {
+  "use strict";
+
+  const MyExtendedController = Controller.extend("test.controller.MyExtendedController", {
     routing: Routing.override({})
   });
   return MyExtendedController;

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-error-1.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-error-1.ts
@@ -6,7 +6,5 @@ import Routing from "sap/fe/core/controllerextensions/Routing";
  * @namespace test.controller
  */
 export default class MyExtendedController extends Controller {
-	routing = ControllerExtension.use(Routing.override({}));
-	routing2 = (Routing as any).use(Routing.override({})); // should not even try to handle this
-	routing3 = Controller.use(Routing.override({})); // should not even try to handle this
+	routing = ControllerExtension.use(); // should throw an error
 }

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-error-2.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-error-2.ts
@@ -6,7 +6,5 @@ import Routing from "sap/fe/core/controllerextensions/Routing";
  * @namespace test.controller
  */
 export default class MyExtendedController extends Controller {
-	routing = ControllerExtension.use(Routing.override({}));
-	routing2 = (Routing as any).use(Routing.override({})); // should not even try to handle this
-	routing3 = Controller.use(Routing.override({})); // should not even try to handle this
+	routing = ControllerExtension.use(1, 2); // should throw an error
 }

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-explicit-type.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-explicit-type.ts
@@ -1,0 +1,14 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+	routing: Routing = ControllerExtension.use(Routing.override({}));
+	routing2: Routing = ControllerExtension.use(Routing.override({
+		x: 1,
+		fn: () => { }
+	}));
+}

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-renamed.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended-renamed.ts
@@ -1,0 +1,17 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import CtrlEx from "sap/ui/core/mvc/ControllerExtension";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+	routing = /* comment */ CtrlEx.use(
+		/* comment */
+		Routing.override(
+			/* comment */
+			{
+				/* comment */
+			}
+		));
+}

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-extended.ts
@@ -1,0 +1,10 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+	routing = ControllerExtension.use(Routing.override({}));
+}

--- a/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-usage-new.ts
+++ b/packages/plugin/__test__/fixtures/typescript/ts-class-controller-extension-usage-new.ts
@@ -1,0 +1,24 @@
+import Controller from "sap/ui/core/mvc/Controller";
+import Routing from "sap/fe/core/controllerextensions/Routing";
+import { OtherExtension } from "sap/fe/core/controllerextensions/OtherExtension";
+import * as ThirdExtension from "sap/fe/core/controllerextensions/ThirdExtension";
+import { SomethingElse, AlmostRemovedExtension } from "sap/fe/core/controllerextensions/DoubleExportExtension";
+import * as extensionCollection from "sap/fe/core/controllerextensions/ManyExtensions";
+import ControllerExtension from "sap/ui/core/mvc/ControllerExtension";
+
+/**
+ * @namespace test.controller
+ */
+export default class MyExtendedController extends Controller {
+
+	routing = ControllerExtension.use(Routing);
+
+	other = ControllerExtension.use(OtherExtension);
+
+	third = ControllerExtension.use(ThirdExtension);
+
+	fourth = ControllerExtension.use(AlmostRemovedExtension);
+
+	fifth = ControllerExtension.use(extensionCollection.group.OneOfManyExtensions);
+
+}

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -18,9 +18,9 @@
     "lint": "eslint src",
     "lint:fix": "npm run lint -- --fix",
     "lint:staged": "lint-staged",
-    "test": "jest __test__ --coverage=no",
+    "test": "FORCE_COLOR=0 jest __test__ --coverage=no",
     "test:watch": "npm test -- --watch",
-    "test:update-snapshot": "jest --updateSnapshot",
+    "test:update-snapshot": "FORCE_COLOR=0 jest --updateSnapshot",
     "prepare": "npm test && npm run build",
     "format": "prettier --write 'src/**/*.js'"
   },

--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -212,6 +212,40 @@ export function convertClassToUI5Extend(
 
       if (!member.value) continue; // remove all other un-initialized static class props (typescript)
 
+      // Now handle the case where an extended controller extension - not just e.g. "Routing", but
+      // "Routing.override({...})" - is assigned to the class property. To make this work in TypeScript code
+      // (Routing.override({...}) returns a class, but the "routing" member property needs to be typed as an instance),
+      // we require the following notation, using a dummy function ControllerExtension.use() that does actually
+      // not exist at runtime, but does the required class-to-instance conversion from TypeScript perspective:
+      //    routing: ControllerExtension.use(Routing.override({...}))
+      // In this case, the code in the "if" clause above was not executed, regardless of the presence of the
+      // @transformControllerExtension marker, because it is not a type assignment. In the resulting code, the
+      // "ControllerExtension.use(...)" part should be removed and the content of the brackets should be assigned
+      // directly to the member property.
+      if (t.isCallExpression(member.value)) {
+        const callee = member.value.callee;
+        if (
+          t.isMemberExpression(callee) &&
+          t.isIdentifier(callee.object) &&
+          t.isIdentifier(callee.property) &&
+          callee.property.name === "use" // we are looking for "ControllerExtension.use(...)"
+        ) {
+          const importDeclaration = getImportDeclaration(
+            memberPath.hub.file.opts.filename,
+            callee.object.name // usually, but not necessarily always: "ControllerExtension"...
+          );
+          // ...hence we rather look at the imported module name to be sure
+          if (
+            importDeclaration.source.value ===
+            "sap/ui/core/mvc/ControllerExtension"
+          ) {
+            member.value = member.value.arguments[0];
+            extendProps.unshift(buildObjectProperty(member)); // add it to the properties of the extend() config object
+            continue; // prevent the member from also being added to the constructor
+          }
+        }
+      }
+
       // Special handling for TypeScript limitation where metadata, renderer and overrides must be properties.
       if (["metadata", "renderer", "overrides"].includes(memberName)) {
         if (opts.overridesToOverride && member.key.name === "overrides") {

--- a/packages/plugin/src/classes/helpers/classes.js
+++ b/packages/plugin/src/classes/helpers/classes.js
@@ -190,7 +190,7 @@ export function convertClassToUI5Extend(
 
           // 3. restore the import in case it was run already and removed the import
           const neededImportDeclaration = getImportDeclaration(
-            memberPath.hub.file.opts.filename,
+            memberPath?.hub?.file?.opts?.filename,
             typeName
           );
           if (
@@ -231,14 +231,25 @@ export function convertClassToUI5Extend(
           callee.property.name === "use" // we are looking for "ControllerExtension.use(...)"
         ) {
           const importDeclaration = getImportDeclaration(
-            memberPath.hub.file.opts.filename,
-            callee.object.name // usually, but not necessarily always: "ControllerExtension"...
+            memberPath?.hub?.file?.opts?.filename,
+            callee?.object?.name // usually, but not necessarily always: "ControllerExtension"...
           );
           // ...hence we rather look at the imported module name to be sure
           if (
-            importDeclaration.source.value ===
+            importDeclaration?.source?.value ===
             "sap/ui/core/mvc/ControllerExtension"
           ) {
+            if (
+              !member.value.arguments ||
+              member.value.arguments.length !== 1
+            ) {
+              // exactly one argument must be there
+              throw memberPath.buildCodeFrameError(
+                `ControllerExtension.use() must be called with exactly one argument but has ${
+                  member.value.arguments ? member.value.arguments.length : 0
+                }`
+              );
+            }
             member.value = member.value.arguments[0];
             extendProps.unshift(buildObjectProperty(member)); // add it to the properties of the extend() config object
             continue; // prevent the member from also being added to the constructor

--- a/packages/plugin/src/classes/helpers/imports.js
+++ b/packages/plugin/src/classes/helpers/imports.js
@@ -11,6 +11,10 @@ export const saveImports = (file) => {
 
 // can be called from visitor to access previously present declarations
 export function getImportDeclaration(filename, typeName) {
+  if (!filename || !typeName) {
+    return null;
+  }
+
   const typeNameParts = typeName.split(".");
 
   // find the declaration importing the typeName among the collected import declarations in this file


### PR DESCRIPTION
Recognize (and remove) a dummy function ControllerExtension.use(...)
that only exists on TypeScript/ES-class side and takes care of
converting the class resulting from SomeExtension.override(...) to the
instance type that needs to be presented to TypeScript for the member
property.

Intentionally does not remove the previous @transformControllerExtension
annotation to not disrupt potential users immediately. But it will be
removed.

Contains some unrelated whitespace fixes for prettier.