### PR TITLE
fix: move qunit config autostart out of require/define

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ void Promise.all([import("unit/controller/App.qunit")]).then(() => {
 will be converted to:
 
 ```js
-"sap.ui.require([], function () {
-  "use strict";
+"use strict";
 
+QUnit.config.autostart = false;
+"sap.ui.require([], function () {
   function __ui5_require_async(path) { /* ... */ }
-  QUnit.config.autostart = false;
   void Promise.all([__ui5_require_async("unit/controller/App.qunit")]).then(() => {
     QUnit.start();
   });
@@ -374,6 +374,8 @@ will be converted to:
 ```
 
 > :warning: Although `sap.ui.define` and `sap.ui.require` may appear similar from an API perspective, they have different behaviors. To understand these differences, please read the section titled "Using sap.ui.require instead of sap.ui.define on the top level" in the [Troubleshooting for Loading Modules](https://ui5.sap.com/#/topic/4363b3fe3561414ca1b030afc8cd30ce).
+
+> :bulb: The plugin detects the global usage of `QUnit.config.autostart` and moves this out of the `sap.ui.require` or `sap.ui.define` block automatically to ensure that the config is applied sychronously when loading the module. The move can be supressed with the configuration option `noWrapQUnitConfigAutostart`. If `QUnit` is imported, e.g. `import QUnit from "qunit";` then this is detected and the autostart config is not moved as it must apply locally.
 
 ### Converting ES classes into Control.extend(..) syntax
 
@@ -795,6 +797,7 @@ In general, comments are preserved, but for each class property/method whose pos
 ### Wrapping
 
 - `noWrapBeforeImport` (Default: false) Does not wrap code before the first import (if there are imports).
+- `noWrapQUnitConfigAutostart` (Default: true) Does not wrap the `QUnit.config.autostart` in the `sap.ui.require` or `sap.ui.define` block.
 
 ### Class Conversion
 

--- a/packages/plugin/__test__/__snapshots__/test.js.snap
+++ b/packages/plugin/__test__/__snapshots__/test.js.snap
@@ -1647,9 +1647,10 @@ exports[`sap-ui-require othermodule-noannotation.js 1`] = `
 `;
 
 exports[`sap-ui-require testsuite-annotation.qunit.js 1`] = `
-"sap.ui.require([], function () {
-  "use strict";
+""use strict";
 
+QUnit.config.autostart = false;
+sap.ui.require([], function () {
   function __ui5_require_async(path) {
     return new Promise(function (resolve, reject) {
       sap.ui.require([path], function (module) {
@@ -1667,6 +1668,37 @@ exports[`sap-ui-require testsuite-annotation.qunit.js 1`] = `
       });
     });
   }
+  void Promise.all([__ui5_require_async("unit/controller/App.qunit")]).then(() => {
+    QUnit.start();
+  });
+});"
+`;
+
+exports[`sap-ui-require testsuite-annotation-with-qunit-import.qunit.js 1`] = `
+"sap.ui.require(["qunit"], function (__QUnit) {
+  "use strict";
+
+  function _interopRequireDefault(obj) {
+    return obj && obj.__esModule && typeof obj.default !== "undefined" ? obj.default : obj;
+  }
+  function __ui5_require_async(path) {
+    return new Promise(function (resolve, reject) {
+      sap.ui.require([path], function (module) {
+        if (!(module && module.__esModule)) {
+          module = module === null || !(typeof module === "object" && path.endsWith("/library")) ? {
+            default: module
+          } : module;
+          Object.defineProperty(module, "__esModule", {
+            value: true
+          });
+        }
+        resolve(module);
+      }, function (err) {
+        reject(err);
+      });
+    });
+  }
+  const QUnit = _interopRequireDefault(__QUnit);
   QUnit.config.autostart = false;
   void Promise.all([__ui5_require_async("unit/controller/App.qunit")]).then(() => {
     QUnit.start();
@@ -1675,9 +1707,10 @@ exports[`sap-ui-require testsuite-annotation.qunit.js 1`] = `
 `;
 
 exports[`sap-ui-require testsuite-noannotation.qunit.js 1`] = `
-"sap.ui.define([], function () {
-  "use strict";
+""use strict";
 
+QUnit.config.autostart = false;
+sap.ui.define([], function () {
   function __ui5_require_async(path) {
     return new Promise(function (resolve, reject) {
       sap.ui.require([path], function (module) {
@@ -1695,7 +1728,6 @@ exports[`sap-ui-require testsuite-noannotation.qunit.js 1`] = `
       });
     });
   }
-  QUnit.config.autostart = false;
   void Promise.all([__ui5_require_async("unit/controller/App.qunit")]).then(() => {
     QUnit.start();
   });

--- a/packages/plugin/__test__/fixtures/sap-ui-require/testsuite-annotation-with-qunit-import.qunit.js
+++ b/packages/plugin/__test__/fixtures/sap-ui-require/testsuite-annotation-with-qunit-import.qunit.js
@@ -1,0 +1,10 @@
+/* @sapUiRequire */
+import QUnit from "qunit";
+
+// https://api.qunitjs.com/config/autostart/
+QUnit.config.autostart = false;
+
+// import all your QUnit tests here
+void Promise.all([import("unit/controller/App.qunit")]).then(() => {
+  QUnit.start();
+});


### PR DESCRIPTION
In case of using QUnit.config.autostart to configure the globally available QUnit, it must be moved out from the sap.ui.require or sap.ui.define block so that it is applied synchronously when loading the module.

If QUnit is required locally, then QUnit.config.autostart will not be moved.

The move can also be supressed by using the configuration option noWrapQUnitConfigAutostart.