### PR TITLE
fix(): fix #139 - autoConvertControllerClass to consider controller.t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,8 @@ In general, comments are preserved, but for each class property/method whose pos
 
 - `namespacePrefix` (Default: '') Prefix to apply to namespace derived from directory.
 - `autoConvertAllExtendClasses` (Default false). Converts all classes by default, provided they extend from an imported class. Version 6 default behaviour.
-- `autoConvertControllerClass` (Default true). Converts the classes in a `.controller.js` file by default, if it extends from an imported class. Use `@nonui5` if there are multiple classes in a controller file which extend from an import.
+- `autoConvertControllerClass` (Default true). Converts the classes in a `.controller.js` (or .ts) file by default, if it extends from an imported class. 
+  Use `@nonui5` if there are multiple classes in a controller file which extend from an import.
 - `neverConvertClass` (Default: false) Never convert classes to SAPClass.extend() syntax.
 - `moveControllerPropsToOnInit` (Default: false) Moves class props in a controller to the onInit method instead of constructor.
 - `moveControllerConstructorToOnInit` (Default: false) Moves existing constructor code in a controller to the onInit method. Enabling will auto-enable `moveControllerPropsToOnInit`.

--- a/packages/plugin/src/classes/visitor.js
+++ b/packages/plugin/src/classes/visitor.js
@@ -229,8 +229,9 @@ function shouldConvertClass(file, node, opts, classInfo) {
   ) {
     return true;
   }
+  // Convert controller classes
   if (
-    /.*[.]controller[.]js$/.test(file.opts.filename) &&
+    /.*[.]controller[.](js|ts)$/.test(file.opts.filename) &&
     opts.autoConvertControllerClass !== false
   ) {
     return true;


### PR DESCRIPTION
Fix for #139 .

When using UI5 CLI with TypeScript integration according to newest best practices, the file name passed by Babel to the plugin is still the original one with extensions .ts (while the content is already JS as transpiled by previous steps of the Babel config).
The plugin is explicitly checking for .controller.js and thus will not convert controller files to 'UI5 format'.

This fix adds .ts as an option in the regex checking the filename.

